### PR TITLE
FIX(Empty response)

### DIFF
--- a/packages/http/src/mock.requestHandler.ts
+++ b/packages/http/src/mock.requestHandler.ts
@@ -1,4 +1,5 @@
 import isObject from 'lodash/isObject';
+import isNil from 'lodash/isNil';
 import { ContentType, HttpRequestHandler, HttpResponse, NormalizedHttpOptions } from './httpClient.types';
 import { HttpStatusText } from './httpCodes';
 
@@ -6,13 +7,13 @@ export const handleRequest = (code: number, body: any, contentType: string = Con
   if (isObject(body)) {
     body = JSON.stringify(body);
     contentType = contentType || ContentType.JSON;
-  } else {
+  } else if (!isNil(body)) {
     body = String(body);
   }
   return Promise.resolve(new Response(body, {
     headers: {
       'Content-Type': contentType,
-      'Content-Length': body.length,
+      'Content-Length': body && body.length,
     },
     status: code,
     statusText: HttpStatusText[code],
@@ -36,7 +37,7 @@ export const mockRequestHandler = (
   mockOptions: MockOptions,
 ): MockHttpRequestHandler => {
   let lastRequest: NormalizedHttpOptions;
-  const handler = async  (
+  const handler = async (
     requestOptions: NormalizedHttpOptions,
   ): Promise<HttpResponse> => {
     lastRequest = requestOptions;

--- a/packages/http/src/spec/httpClient.spec.ts
+++ b/packages/http/src/spec/httpClient.spec.ts
@@ -33,4 +33,45 @@ describe('HttpClient', () => {
       expect(await result.parsedBody()).toEqual('2');
     });
   });
+
+  describe('interceptor', () => {
+    const log = jest.fn();
+    const client = new HttpClient({
+      requestHandler: mockRequestHandler({
+        endpoints: [
+          {
+            match: 'https://fakeland.com/endpoint',
+            handler: () => handleRequest(200, '1'),
+          },
+          {
+            match: 'https://fakeland2.com/endpoint',
+            handler: () => handleRequest(200, '2'),
+          }
+        ],
+      }),
+      baseUrl: 'https://fakeland.com/',
+      responseParser: bodyParser(),
+    }).addInterceptor((request, options) => {
+      log(options);
+      return async () => {
+        const result = await request();
+        log(await result.parsedBody());
+        return result;
+      };
+    });
+
+    it('intercepts a call', async () => {
+      const result = await client.get('/endpoint');
+      expect(result.status).toEqual(200);
+      expect(await result.parsedBody()).toEqual('1');
+      expect(log).toHaveBeenCalledTimes(2);
+      expect(log).toHaveBeenNthCalledWith(1, {
+        body: undefined,
+        headers: {},
+        method: 'GET',
+        url: 'https://fakeland.com/endpoint',
+      });
+      expect(log).toHaveBeenNthCalledWith(2, '1');
+    });
+  });
 });

--- a/packages/json-api/src/jsonApi.builder.ts
+++ b/packages/json-api/src/jsonApi.builder.ts
@@ -115,15 +115,16 @@ export abstract class RequestBuilder<ResponseType> {
   }
 
   protected async parseResponse<Raw extends RawResponse<any, any>>(response: HttpResponse): Promise<JsonResponse<Raw>> {
-    const body = await response.parsedBody();
-    let responseData = body.data;
+    const body = (await response.parsedBody()) || undefined;
+    if (body) {
+      let responseData = body.data;
 
-    if (this.resolveIncludedRelationships && body.included) {
-      responseData = resolveRelationships(responseData, body.included);
+      if (this.resolveIncludedRelationships && body.included) {
+        responseData = resolveRelationships(responseData, body.included);
+      }
+
+      body.data = responseData;
     }
-
-    body.data = responseData;
-
     return new JsonResponse(body, response);
   }
 }

--- a/packages/json-api/src/jsonApi.response.ts
+++ b/packages/json-api/src/jsonApi.response.ts
@@ -8,10 +8,10 @@ export class JsonResponse<Raw extends RawResponse<any, any>> {
   }
 
   get element(): MergedData<Raw['data']> {
-    return mergeElementData(this.raw.data);
+    return this.raw && mergeElementData(this.raw.data);
   }
 
   get meta(): Raw['meta'] {
-    return this.raw.meta;
+    return this.raw && this.raw.meta;
   }
 }

--- a/packages/json-api/src/spec/httpClient.setup.ts
+++ b/packages/json-api/src/spec/httpClient.setup.ts
@@ -9,7 +9,15 @@ import {
   MockHttpRequestHandler,
   mockRequestHandler,
 } from '@coolio/http';
-import { DELETE_MOCK, GET_LIST_MOCK, GET_MOCK, PATCH_MOCK, POST_MOCK, PUT_MOCK } from './jsonApi.mocks';
+import {
+  DELETE_MOCK,
+  GET_LIST_MOCK,
+  GET_MOCK,
+  PATCH_MOCK,
+  POST_EMPTY_MOCK,
+  POST_MOCK,
+  PUT_MOCK
+} from './jsonApi.mocks';
 
 export interface HttpMock {
   requestHandler: MockHttpRequestHandler;
@@ -23,6 +31,10 @@ export const createHttpMock = (): HttpMock => {
       {
         match: GET_MOCK.URI,
         handler: ok(GET_MOCK.RAW),
+      },
+      {
+        match: POST_EMPTY_MOCK.URI,
+        handler: () => handleRequest(HttpCode.ACCEPTED, undefined, ContentType.VND_JSON),
       },
       {
         match: GET_LIST_MOCK.URI,

--- a/packages/json-api/src/spec/jsonApi.mocks.ts
+++ b/packages/json-api/src/spec/jsonApi.mocks.ts
@@ -139,6 +139,11 @@ export const POST_MOCK = {
   },
 };
 
+export const POST_EMPTY_MOCK = {
+  ...POST_MOCK,
+  URI: 'https://example.com/post-empty',
+};
+
 export const PUT_MOCK = {
   URI: 'https://example.com/put',
   ID: 'testId',

--- a/packages/json-api/src/spec/jsonApi.post.spec.ts
+++ b/packages/json-api/src/spec/jsonApi.post.spec.ts
@@ -1,6 +1,6 @@
 import { JsonApiClient } from '../jsonApi.client';
 import { createHttpMock, HttpMock } from './httpClient.setup';
-import { DEFAULT_HEADERS_MOCK, GET_MOCK, POST_MOCK } from './jsonApi.mocks';
+import { DEFAULT_HEADERS_MOCK, GET_MOCK, POST_EMPTY_MOCK, POST_MOCK } from './jsonApi.mocks';
 
 describe('JSON API Post', () => {
   let mock: HttpMock;
@@ -11,6 +11,21 @@ describe('JSON API Post', () => {
 
   it('should throw an error when type is missing in request', () => {
     expect(() => new JsonApiClient(mock.httpClient).post('').send()).toThrowError('Missing object type');
+  });
+
+  it('should not fail when response is empty', async () => {
+    const postBuilder = new JsonApiClient(mock.httpClient)
+      .post(POST_EMPTY_MOCK.URI)
+      .ofType('testType')
+      .withAttributes(POST_MOCK.ATTRIBUTES)
+      .withRelationship()
+      .withRelationship(POST_MOCK.RELATIONSHIP)
+      .withRelationship(POST_MOCK.RELATIONSHIP_2);
+
+    const result = await postBuilder.send();
+    expect(result.raw).toEqual(undefined);
+    expect(result.element).toEqual(undefined);
+    expect(result.meta).toEqual(undefined);
   });
 
   it('should produce correct request with PostBuilder', async () => {


### PR DESCRIPTION
Coolio should not fail when response is empty, even when `content-type` is set. Currently JSON API always tries to parse the response. The fix consists of 2 parts:
- Make JSON API handle undefined/null response properly
- Check `content-length` when trying to parse JSON (also mock tool was improved)