### PR TITLE
FEAT(Query support)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,6 +30,6 @@ module.exports = {
     'import/order': ['error', {
       'groups': ['external', 'internal'],
     }],
-
+    'quote-props': ['error', 'consistent-as-needed'],
   },
 };

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -45,7 +45,12 @@ import { Config } from './config';
 import { User } from './user.types';
 
 const getUsers = async (): Promise<User[]> => {
-  const response = await httpClient.get(`${Config.API_BASE_URL}/users`);
+  const response = await httpClient.get(`${Config.API_BASE_URL}/users`, {
+    query: {
+      page: 3,
+      limit: 10,
+    },
+  });
   const body = await response.parsedBody();
   return body.data;
 };

--- a/packages/http/src/bodyParser.ts
+++ b/packages/http/src/bodyParser.ts
@@ -1,12 +1,10 @@
-import * as qs from 'qs';
 import { BodyCasing, getCaseConverter } from './helpers';
 import { ContentType, HttpResponse } from './httpClient.types';
+import { urlDecode } from './helpers/urlEncoding.helper';
 
 export interface BodyParserOptions {
   bodyCasing?: BodyCasing;
 }
-
-const parseUrlEncodedBody = (body: string) => qs.parse(body);
 
 export const bodyParser = ({
   bodyCasing,
@@ -29,7 +27,7 @@ export const bodyParser = ({
         break;
       case ContentType.URL_ENCODED:
         response.parsedBody = () => response.text()
-          .then(parseUrlEncodedBody)
+          .then(urlDecode)
           .then(caseConverter);
         break;
       case ContentType.TEXT:

--- a/packages/http/src/bodySerializer.ts
+++ b/packages/http/src/bodySerializer.ts
@@ -1,11 +1,10 @@
 import isNil from 'lodash/isNil';
 import isString from 'lodash/isString';
 import isBuffer from 'lodash/isBuffer';
-import * as qs from 'qs';
 import { BodySerializer, ContentType, HttpOptions, NormalizedHttpBody } from './httpClient.types';
 import { BodyCasing, getCaseConverter, getHeader } from './helpers';
+import { urlEncode } from './helpers/urlEncoding.helper';
 
-const serializeUrlEncodedBody = (body: any) => qs.stringify(body);
 
 export interface BodySerializerOptions {
   bodyCasing?: BodyCasing;
@@ -31,7 +30,7 @@ export const bodySerializer = ({
           case ContentType.VND_JSON:
             return JSON.stringify(caseConverter(options.body));
           case ContentType.URL_ENCODED:
-            return serializeUrlEncodedBody(caseConverter(options.body));
+            return urlEncode(caseConverter(options.body));
           case ContentType.TEXT:
             return String(body);
           default:

--- a/packages/http/src/helpers/caseConversion.helper.spec.ts
+++ b/packages/http/src/helpers/caseConversion.helper.spec.ts
@@ -12,8 +12,8 @@ import {
 } from './caseConversion.helper';
 
 const conversionMockup = {
-  first_field: 'x',
-  three_word_field: 'b',
+  'first_field': 'x',
+  'three_word_field': 'b',
   'kebab-case-field': {
     'an array': [
       'a',
@@ -127,16 +127,16 @@ describe('caseConversion.helper', () => {
   describe('#toSnakeCase', () => {
     it('converts mixed case object to snake_case', () => {
       expect(toSnakeCase(conversionMockup)).toEqual({
-        'first_field': 'x',
-        'three_word_field': 'b',
-        'kebab_case_field': {
-          'an_array': [
+        first_field: 'x',
+        three_word_field: 'b',
+        kebab_case_field: {
+          an_array: [
             'a',
             'b',
             {
-              'pascal_case': {
-                'value': 'x',
-                'value_two': 'y',
+              pascal_case: {
+                value: 'x',
+                value_two: 'y',
               },
             },
           ],

--- a/packages/http/src/helpers/index.ts
+++ b/packages/http/src/helpers/index.ts
@@ -1,3 +1,4 @@
 export * from './httpClient.helper';
 export * from './headers.helper';
 export * from './caseConversion.helper';
+export * from './urlEncoding.helper';

--- a/packages/http/src/helpers/spec/urlEncoding.helper.spec.ts
+++ b/packages/http/src/helpers/spec/urlEncoding.helper.spec.ts
@@ -1,0 +1,41 @@
+import { urlCombine, urlDestruct } from '../urlEncoding.helper';
+
+describe('urlEncoding.helper', () => {
+  describe('urlCombine', () => {
+    it('combines "http://example.com/path" URL with "{ test: 1, values: 2 }" query params', () => {
+      const combinedUrl = urlCombine('http://example.com/path', { test: 1, values: 2 });
+      expect(combinedUrl).toEqual('http://example.com/path?test=1&values=2');
+    });
+
+    it('overrides and merges nested parameters in URL by query params object', () => {
+      const combinedUrl = urlCombine('http://example.com/path?obj[a]=a&obj[b]=b', {
+        obj: { b: 'override', c: 'c' },
+        d: 1
+      });
+      expect(combinedUrl).toEqual('http://example.com/path?obj[a]=a&obj[b]=override&obj[c]=c&d=1');
+    });
+    it('doesn\'t add query string when query is empty', () => {
+      const combinedUrl = urlCombine('http://example.com', {});
+      expect(combinedUrl).toEqual('http://example.com');
+    });
+  });
+
+  describe('urlDestruct', () => {
+    it('breaks down url with query params to a path and query params object', () => {
+      const breakdown = urlDestruct('http://example.com/path?obj[a]=a&obj[b]=b');
+      expect(breakdown).toEqual({
+        url: 'http://example.com/path',
+        query: {
+          obj: {
+            a: 'a',
+            b: 'b',
+          },
+        },
+      });
+    });
+    it('returns empty query object when there is no query', () => {
+      expect(urlDestruct('http://example.com/path').query).toEqual({});
+      expect(urlDestruct('http://example.com/path?').query).toEqual({});
+    });
+  });
+});

--- a/packages/http/src/helpers/urlEncoding.helper.ts
+++ b/packages/http/src/helpers/urlEncoding.helper.ts
@@ -1,0 +1,27 @@
+import * as qs from 'qs';
+import merge from 'lodash/merge';
+
+export const urlDestruct = (url: string): {
+  url: string;
+  query: any;
+} => {
+  const [path, query] = url.split('?');
+  return {
+    url: path,
+    query: query ? urlDecode(query) : {},
+  };
+};
+
+export const urlCombine = (sourceUrl: string, sourceQuery?: object) => {
+  const { url, query } = urlDestruct(sourceUrl);
+  const queryString = urlEncode(merge(query, sourceQuery), {
+    addQueryPrefix: false,
+  });
+  return url + (queryString ? `?${queryString}` : '');
+};
+
+export const urlEncode = (value: any, options?: qs.IStringifyOptions) => qs.stringify(value, {
+  encodeValuesOnly: true,
+  ...options,
+});
+export const urlDecode = <T = any>(value: string, options?: qs.IParseOptions): T => qs.parse(value, options);

--- a/packages/http/src/httpClient.types.ts
+++ b/packages/http/src/httpClient.types.ts
@@ -45,6 +45,7 @@ export enum HttpMethod {
 export type RequestMode = 'navigate' | 'same-origin' | 'no-cors' | 'cors';
 
 export interface HttpOptions {
+  query?: object;
   mode?: RequestMode;
   method?: HttpMethod;
   headers?: HttpHeaders;
@@ -56,6 +57,7 @@ export type NormalizedHttpBody = string | TypedArray | undefined;
 
 export interface NormalizedHttpOptions {
   url: string;
+  query: any;
   body?: NormalizedHttpBody;
   method?: HttpMethod;
   headers?: Record<string, string>;

--- a/packages/json-api/src/jsonApi.builder.ts
+++ b/packages/json-api/src/jsonApi.builder.ts
@@ -105,15 +105,6 @@ export abstract class RequestBuilder<ResponseType> {
     return params;
   }
 
-  public get requestUriString() {
-    const unescapedKeys = ['sort'];
-
-    const queryString = Object.entries(this.parameters)
-      .map(([key, value]) => `${key}=${unescapedKeys.includes(key) ? value : encodeURIComponent(value)}`)
-      .join('&');
-    return this.uri + (queryString ? '?' + queryString : '');
-  }
-
   protected async parseResponse<Raw extends RawResponse<any, any>>(response: HttpResponse): Promise<JsonResponse<Raw>> {
     const body = (await response.parsedBody()) || undefined;
     if (body) {

--- a/packages/json-api/src/jsonApi.get.ts
+++ b/packages/json-api/src/jsonApi.get.ts
@@ -10,8 +10,9 @@ export class GetBuilder<Raw extends RawResponse<any, any>> extends RequestBuilde
   }
 
   send(options?: HttpOptions): Promise<JsonResponse<Raw>> {
-    return this.httpClient.get<Raw>(this.requestUriString, {
+    return this.httpClient.get<Raw>(this.uri, {
       ...options,
+      query: this.parameters,
       headers: { ...Headers, ...options && options.headers },
     })
       .then(response => this.parseResponse(response));

--- a/packages/json-api/src/jsonApi.getList.ts
+++ b/packages/json-api/src/jsonApi.getList.ts
@@ -57,8 +57,9 @@ export class GetListBuilder<Raw extends RawListResponse<any, any>, I extends Inc
   }
 
   send(options?: HttpOptions): Promise<JsonListResponse<Raw, I>> {
-    return this.httpClient.get<Raw>(this.requestUriString, {
+    return this.httpClient.get<Raw>(this.uri, {
       ...options,
+      query: this.parameters,
       headers: { ...Headers, ...options && options.headers },
     })
       .then(async response => {

--- a/packages/json-api/src/jsonApi.post.ts
+++ b/packages/json-api/src/jsonApi.post.ts
@@ -38,8 +38,9 @@ export class PostBuilder<Raw extends RawResponse<any, any>> extends RequestBuild
     if (!this.type) {
       throw new Error('Missing object type');
     }
-    return this.httpClient.post<Raw>(this.requestUriString, {
+    return this.httpClient.post<Raw>(this.uri, {
       ...options,
+      query: this.parameters,
       body: {
         data: {
           type: this.type,

--- a/packages/json-api/src/jsonApi.remove.ts
+++ b/packages/json-api/src/jsonApi.remove.ts
@@ -10,8 +10,9 @@ export class RemoveBuilder<Raw extends RawResponse<any, any>> extends RequestBui
   }
 
   send(options: HttpOptions = {}): Promise<JsonResponse<Raw>> {
-    return this.httpClient.remove<Raw>(this.requestUriString, {
+    return this.httpClient.remove<Raw>(this.uri, {
       ...options,
+      query: this.parameters,
       headers: { ...Headers, ...options.headers },
     })
       .then(response => this.parseResponse(response));

--- a/packages/json-api/src/jsonApi.update.ts
+++ b/packages/json-api/src/jsonApi.update.ts
@@ -46,14 +46,15 @@ export class UpdateBuilder<Raw extends RawResponse<any, any>> extends RequestBui
     }
 
     const handlerMap = {
-      'PUT': this.httpClient.put.bind(this.httpClient),
-      'PATCH': this.httpClient.patch.bind(this.httpClient),
+      PUT: this.httpClient.put.bind(this.httpClient),
+      PATCH: this.httpClient.patch.bind(this.httpClient),
     };
 
     const handler = handlerMap[this.method];
 
-    return handler<Raw>(this.requestUriString, {
+    return handler<Raw>(this.uri, {
       ...options,
+      query: this.parameters,
       body: {
         data: {
           id: this.id,

--- a/packages/json-api/src/spec/jsonApi.builder.spec.ts
+++ b/packages/json-api/src/spec/jsonApi.builder.spec.ts
@@ -58,6 +58,7 @@ describe('JSON API RequestBuilder', () => {
     expect(mock.requestHandler.lastRequest()).toEqual({
       url: GET_MOCK.URI,
       method: 'GET',
+      query: {},
       headers: { ...DEFAULT_HEADERS_MOCK, ...CUSTOM_HEADERS },
     });
   });

--- a/packages/json-api/src/spec/jsonApi.get.spec.ts
+++ b/packages/json-api/src/spec/jsonApi.get.spec.ts
@@ -24,11 +24,9 @@ describe('JSON API Get', () => {
 
   it('should produce correct request with GetBuilder', async () => {
     const client = new JsonApiClient(mock.httpClient);
-    const getBuilder = client.get<Data<{}>>('');
-    expect(getBuilder.requestUriString).toEqual('');
-    getBuilder.uri = GET_MOCK.URI;
+    const getBuilder = client.get<Data<{}>>(GET_MOCK.URI);
+    expect(getBuilder.uri).toEqual(GET_MOCK.URI);
     expect(getBuilder.parameters).toEqual({});
-    expect(getBuilder.requestUriString).toEqual(GET_MOCK.URI);
 
     getBuilder
       .filter('element', 'value')
@@ -54,23 +52,35 @@ describe('JSON API Get', () => {
       'sort': 'sortAsc,-sortDesc',
     });
 
-    expect(getBuilder.requestUriString).toEqual(
-      GET_MOCK.URI +
-      '?filter[element]=value' +
-      '&filter[elementEq][EQ]=valueEq' +
-      '&filter[elementNeq][NEQ]=valueNeq' +
-      '&filter[elementLike][LIKE]=valueLike' +
-      '&filter[elementGt][GT]=3' +
-      '&filter[elementGte][GE]=5' +
-      '&filter[elementLt][LT]=-3' +
-      '&filter[elementLt][LE]=-5' +
-      '&sort=sortAsc,-sortDesc',
-    );
-
     const result = await getBuilder.send();
     expect(result.raw).toEqual(GET_MOCK.RAW);
     expect(mock.requestHandler.lastRequest()).toEqual({
-      url: getBuilder.requestUriString,
+      url: 'https://example.com/list/123?filter[element]=value&filter[elementEq][EQ]=valueEq&filter[elementNeq][NEQ]=valueNeq&filter[elementLike][LIKE]=valueLike&filter[elementGt][GT]=3&filter[elementGte][GE]=5&filter[elementLt][LT]=-3&filter[elementLt][LE]=-5&sort=sortAsc%2C-sortDesc',
+      query: {
+        filter: {
+          element: 'value',
+          elementEq: {
+            EQ: 'valueEq'
+          },
+          elementGt: {
+            GT: '3'
+          },
+          elementGte: {
+            GE: '5'
+          },
+          elementLike: {
+            LIKE: 'valueLike'
+          },
+          elementLt: {
+            LE: '-5',
+            LT: '-3'
+          },
+          elementNeq: {
+            NEQ: 'valueNeq'
+          }
+        },
+        sort: 'sortAsc,-sortDesc'
+      },
       method: 'GET',
       headers: DEFAULT_HEADERS_MOCK,
     });

--- a/packages/json-api/src/spec/jsonApi.getList.spec.ts
+++ b/packages/json-api/src/spec/jsonApi.getList.spec.ts
@@ -5,8 +5,6 @@ import { Data } from '../jsonApi.interface';
 import { createHttpMock, HttpMock } from './httpClient.setup';
 import { DEFAULT_HEADERS_MOCK, GET_LIST_MOCK } from './jsonApi.mocks';
 
-const DEFAULT_PARAMS_QUERY_STRING = '?page[limit]=10&page[number]=1';
-
 describe('JSON API Get List', () => {
   let mock: HttpMock;
 
@@ -27,15 +25,13 @@ describe('JSON API Get List', () => {
   });
 
   it('should produce correct request with GetListBuilder', async () => {
-    const getListBuilder = new JsonApiClient(mock.httpClient).getList<Data<{}>>('');
+    const getListBuilder = new JsonApiClient(mock.httpClient).getList<Data<{}>>(GET_LIST_MOCK.URI);
     // Default page limit and offset is always applied
-    expect(getListBuilder.requestUriString).toEqual(DEFAULT_PARAMS_QUERY_STRING);
-    getListBuilder.uri = GET_LIST_MOCK.URI;
+    expect(getListBuilder.uri).toEqual(GET_LIST_MOCK.URI);
     expect(getListBuilder.parameters).toEqual({
       'page[limit]': '10',
       'page[number]': '1',
     });
-    expect(getListBuilder.requestUriString).toEqual(GET_LIST_MOCK.URI + DEFAULT_PARAMS_QUERY_STRING);
 
     getListBuilder
       .filter('element', 'value')
@@ -66,25 +62,39 @@ describe('JSON API Get List', () => {
       'page[offset]': '30',
     });
 
-    expect(getListBuilder.requestUriString).toEqual(
-      GET_LIST_MOCK.URI +
-      '?filter[element]=value' +
-      '&filter[elementEq][EQ]=valueEq' +
-      '&filter[elementNeq][NEQ]=valueNeq' +
-      '&filter[elementLike][LIKE]=valueLike' +
-      '&filter[elementGt][GT]=3' +
-      '&filter[elementGte][GE]=5' +
-      '&filter[elementLt][LT]=-3' +
-      '&filter[elementLt][LE]=-5' +
-      '&sort=sortAsc,-sortDesc' +
-      '&page[limit]=10' +
-      '&page[offset]=30',
-    );
-
     const result = await getListBuilder.send();
     expect(result.raw).toEqual(GET_LIST_MOCK.RAW);
     expect(mock.requestHandler.lastRequest()).toEqual({
-      url: getListBuilder.requestUriString,
+      url: 'https://example.com/list?filter[element]=value&filter[elementEq][EQ]=valueEq&filter[elementNeq][NEQ]=valueNeq&filter[elementLike][LIKE]=valueLike&filter[elementGt][GT]=3&filter[elementGte][GE]=5&filter[elementLt][LT]=-3&filter[elementLt][LE]=-5&sort=sortAsc%2C-sortDesc&page[limit]=10&page[offset]=30',
+      query: {
+        filter: {
+          element: 'value',
+          elementEq: {
+            EQ: 'valueEq'
+          },
+          elementGt: {
+            GT: '3'
+          },
+          elementGte: {
+            GE: '5'
+          },
+          elementLike: {
+            LIKE: 'valueLike'
+          },
+          elementLt: {
+            LE: '-5',
+            LT: '-3'
+          },
+          elementNeq: {
+            NEQ: 'valueNeq'
+          }
+        },
+        page: {
+          limit: '10',
+          offset: '30'
+        },
+        sort: 'sortAsc,-sortDesc'
+      },
       method: 'GET',
       headers: DEFAULT_HEADERS_MOCK,
     });

--- a/packages/json-api/src/spec/jsonApi.post.spec.ts
+++ b/packages/json-api/src/spec/jsonApi.post.spec.ts
@@ -29,11 +29,9 @@ describe('JSON API Post', () => {
   });
 
   it('should produce correct request with PostBuilder', async () => {
-    const postBuilder = new JsonApiClient(mock.httpClient).post('');
-    expect(postBuilder.requestUriString).toEqual('');
-    postBuilder.uri = POST_MOCK.URI;
+    const postBuilder = new JsonApiClient(mock.httpClient).post(POST_MOCK.URI);
+    expect(postBuilder.uri).toEqual(POST_MOCK.URI);
     expect(postBuilder.parameters).toEqual({});
-    expect(postBuilder.requestUriString).toEqual(POST_MOCK.URI);
 
     postBuilder
       .ofType('testType')
@@ -46,7 +44,8 @@ describe('JSON API Post', () => {
 
     expect(result.raw).toEqual(GET_MOCK.RAW);
     expect(mock.requestHandler.lastRequest()).toEqual({
-      url: postBuilder.requestUriString,
+      url: postBuilder.uri,
+      query: {},
       method: 'POST',
       headers: DEFAULT_HEADERS_MOCK,
       body: JSON.stringify(POST_MOCK.BODY),

--- a/packages/json-api/src/spec/jsonApi.remove.spec.ts
+++ b/packages/json-api/src/spec/jsonApi.remove.spec.ts
@@ -10,17 +10,16 @@ describe('JSON API Remove', () => {
   });
 
   it('should produce correct request with RemoveBuilder', async () => {
-    const builder = new JsonApiClient(mock.httpClient).remove('');
-    expect(builder.requestUriString).toEqual('');
-    builder.uri = DELETE_MOCK.URI;
+    const builder = new JsonApiClient(mock.httpClient).remove(DELETE_MOCK.URI);
+    expect(builder.uri).toEqual(DELETE_MOCK.URI);
     expect(builder.parameters).toEqual({});
-    expect(builder.requestUriString).toEqual(DELETE_MOCK.URI);
 
     await builder.send();
 
     expect(mock.requestHandler.lastRequest()).toEqual({
       url: DELETE_MOCK.URI,
       method: 'DELETE',
+      query: {},
       headers: DEFAULT_HEADERS_MOCK,
     });
   });

--- a/packages/json-api/src/spec/jsonApi.update.spec.ts
+++ b/packages/json-api/src/spec/jsonApi.update.spec.ts
@@ -15,11 +15,9 @@ describe('JSON API Put', () => {
   });
 
   it('should produce correct request with PutBuilder', async () => {
-    const putBuilder = new JsonApiClient(mock.httpClient).put('');
-    expect(putBuilder.requestUriString).toEqual('');
-    putBuilder.uri = PUT_MOCK.URI;
+    const putBuilder = new JsonApiClient(mock.httpClient).put(PUT_MOCK.URI);
+    expect(putBuilder.uri).toEqual(PUT_MOCK.URI);
     expect(putBuilder.parameters).toEqual({});
-    expect(putBuilder.requestUriString).toEqual(PUT_MOCK.URI);
 
     putBuilder
       .ofType(PUT_MOCK.TYPE)
@@ -32,7 +30,8 @@ describe('JSON API Put', () => {
 
     expect(result.raw).toEqual(GET_MOCK.RAW);
     expect(mock.requestHandler.lastRequest()).toEqual({
-      url: putBuilder.requestUriString,
+      url: putBuilder.uri,
+      query: {},
       method: 'PUT',
       headers: DEFAULT_HEADERS_MOCK,
       body: JSON.stringify(PUT_MOCK.BODY),
@@ -40,11 +39,9 @@ describe('JSON API Put', () => {
   });
 
   it('should produce correct request with PatchBuilder', async () => {
-    const patchBuilder = new JsonApiClient(mock.httpClient).patch('');
-    expect(patchBuilder.requestUriString).toEqual('');
-    patchBuilder.uri = PATCH_MOCK.URI;
+    const patchBuilder = new JsonApiClient(mock.httpClient).patch(PATCH_MOCK.URI);
+    expect(patchBuilder.uri).toEqual(PATCH_MOCK.URI);
     expect(patchBuilder.parameters).toEqual({});
-    expect(patchBuilder.requestUriString).toEqual(PATCH_MOCK.URI);
 
     patchBuilder
       .ofType(PATCH_MOCK.TYPE)
@@ -57,7 +54,8 @@ describe('JSON API Put', () => {
 
     expect(result.raw).toEqual(GET_MOCK.RAW);
     expect(mock.requestHandler.lastRequest()).toEqual({
-      url: patchBuilder.requestUriString,
+      url: patchBuilder.uri,
+      query: {},
       method: 'PATCH',
       headers: DEFAULT_HEADERS_MOCK,
       body: JSON.stringify(PATCH_MOCK.BODY),


### PR DESCRIPTION
This adds support for `query` object to be passed directly to httpClient.get/post/put/patch... operations. Later the object is stored in `normalizedHttpOptions`, so that interceptors can easily add new params and modify them. Before the real call is made, all query params are combined with the URL.