### PR TITLE
fix(http): body cache fix

### DIFF
--- a/packages/http/src/helpers/spec/parsedBodyCache.helper.spec.ts
+++ b/packages/http/src/helpers/spec/parsedBodyCache.helper.spec.ts
@@ -17,6 +17,7 @@ describe('HttpClient Helpers #cacheParsedBody', () => {
     await expect(parsedBody()).resolves.toEqual({ a: 1 });
     await expect(parsedBody()).resolves.toEqual({ a: 1 });
   });
+
   it('works correctly when multiple calls are made before Promise resolves', async () => {
     let resolve: any;
     const f = () => new Promise(r => {


### PR DESCRIPTION
Fix for the issue: If server returns null response body, and one calls parsedBody() more than once in an asynchronous manner, then parsedBody() promise is never resolved.