### PR TITLE
feat(oauth2interceptor): token-type can be optional

### DIFF
--- a/packages/auth-interceptor/README.md
+++ b/packages/auth-interceptor/README.md
@@ -61,7 +61,7 @@ const authInterceptor = createAuthInterceptor({
     if (!options.headers) {
       options.headers = {};
     }
-    options.headers['Authorization'] = `${tokenType} ${accessToken}`;
+    options.headers['Authorization'] = tokenType ? `${tokenType} ${accessToken}` : accessToken;
   },
   onAuthorizationFailure: (error: Error) => {
     console.log(error.message);
@@ -83,7 +83,7 @@ export const httpClient = new HttpClient({
 
 Now each request directed to `my-domain.org` has a proper `Authorization` header.
 In case of `401` response, all requests are paused and token refresh happens.
-When token is fresh, all requests are resumed. 
+When token is fresh, all requests are resumed.
 The whole process is transparent and doesn't affect calls.
 
 ## OAuth2 Usage

--- a/packages/auth-interceptor/src/oauth2Interceptor.ts
+++ b/packages/auth-interceptor/src/oauth2Interceptor.ts
@@ -57,7 +57,7 @@ export const createOAuth2Interceptor = ({
     setAuthorizationData: async (options: NormalizedHttpOptions) => {
       // Get previously stored tokens
       const { accessToken, tokenType } = await getAuthData();
-      options.headers['Authorization'] = `${tokenType} ${accessToken}`;
+      options.headers['Authorization'] = tokenType ? `${tokenType} ${accessToken}` : accessToken;
     },
     onAuthorizationFailure,
     canAuthorize,

--- a/packages/auth-interceptor/src/oauth2Interceptor.types.ts
+++ b/packages/auth-interceptor/src/oauth2Interceptor.types.ts
@@ -5,7 +5,7 @@ import { AuthError } from './authError';
 
 export interface OAuth2TokenResponse {
   accessToken: string;
-  tokenType: string;
+  tokenType?: string;
   idToken?: string;
   expires?: string;
   expiresIn?: string;


### PR DESCRIPTION
Made tokenType optional. If it's not present, only accessToken will be used in the header