### PR TITLE
feat(json-api): query params can be any object or array

### DIFF
--- a/packages/json-api/src/requestBuilders/requestBuilder.ts
+++ b/packages/json-api/src/requestBuilders/requestBuilder.ts
@@ -23,17 +23,17 @@ export class RequestBuilder<D extends AnyData, M extends {} = {}> {
 
   parameter(
     key: string,
-    value: string | number | boolean | undefined,
+    value: any,
   ): this {
     if (key && !isNil(value)) {
-      this.requestData.query[key] = value.toString();
+      this.requestData.query[key] = value;
     }
     return this;
   }
 
   filter(
     key: string | string[],
-    value: string | number | boolean | undefined,
+    value: any,
   ): this {
     const queryKey = Array.isArray(key)
       ? (key.length ? `filter[${key.join('][')}]` : '')

--- a/packages/json-api/src/requestData.ts
+++ b/packages/json-api/src/requestData.ts
@@ -11,7 +11,7 @@ export interface RequestBuilderOptions {
 }
 
 export class JsonApiRequestData {
-  query: Record<string, string> = {};
+  query: Record<string, any> = {};
   sort: string[] = [];
   body: any;
   limit = DEFAULT_RESOURCE_LIMIT;

--- a/packages/json-api/src/spec/requestBuilder.spec.ts
+++ b/packages/json-api/src/spec/requestBuilder.spec.ts
@@ -51,6 +51,16 @@ describe('JSON API RequestBuilder', () => {
     });
   });
 
+  it('produces correct request for filters with array of elements', async () => {
+    const client = new JsonApiClient(mock.httpClient);
+    await client.get<Data<{}>>(GetMock.uri)
+      .filter('key1', ['value1', 'value2', 'value3'])
+      .filter(['something', 'nested'], ['v1', 'v2', 'v3', 'v4'])
+      .expectOne()
+      .send();
+    expect(mock.requestHandler.lastRequest().url).toEqual('https://example.com/list/123?filter[key1][0]=value1&filter[key1][1]=value2&filter[key1][2]=value3&filter[something][nested][0]=v1&filter[something][nested][1]=v2&filter[something][nested][2]=v3&filter[something][nested][3]=v4');
+  });
+
   it('produces correct request for list of resources', async () => {
     const result = await new JsonApiClient(mock.httpClient)
       .get<Data<{}>>(GetListMock.uri)


### PR DESCRIPTION
Previously one was not able to filter single field by multiple values in JsonApiClient. Now it's possible.