### PR TITLE
fix(json-api): resolve relationship arrays correctly

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -21,7 +21,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-yarn-
     - run: yarn
-    - run: yarn audit --groups dependencies
+    - run: yarn audit:ci
     - run: yarn compile
     - name: Upload built packages
       uses: actions/upload-artifact@v2-preview

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "license": "MIT",
   "private": true,
   "scripts": {
+    "audit:ci": "./scripts/audit.sh",
     "postinstall": "lerna bootstrap && yarn link:all && yarn generate",
     "compile:watch": "lerna exec --parallel 'yarn compile:watch'",
     "generate": "yarn generate:tsconfig && yarn generate:bindings",

--- a/scripts/audit.sh
+++ b/scripts/audit.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+yarn audit --groups dependencies
+level=$?
+if [[ $level -eq 0 ]]; then
+  echo "No issues found. We're good to go."
+elif [[ $level -le 4 ]]; then
+  echo "Found issues during audit, however they're below MODERATE level. Ignoring..."
+else
+  echo "Found serious issues. Failing build."
+  exit 1
+fi


### PR DESCRIPTION
* normalize array when at least one object is a complex object
* previously first object in array had to be a complex object in order to perform normalization instead of returning plain identifiers