### PR TITLE
feat(http): custom case conversion

### DIFF
--- a/packages/http/src/bodyParser.ts
+++ b/packages/http/src/bodyParser.ts
@@ -1,4 +1,4 @@
-import { BodyCasing, getBoundaryFromContentTypeHeader, getCaseConverter, processMultipartBody } from './helpers';
+import { BodyCasing, CaseConverter, getBoundaryFromContentTypeHeader, getCaseConverter, processMultipartBody } from './helpers';
 import { BodyParser, HttpResponse, RawHttpResponse } from './httpClient.types';
 import { urlDecode } from './helpers/urlEncoding.helper';
 import { ContentTypeMap, switchContentType } from './contentType';
@@ -7,14 +7,16 @@ type BodyParserImplementation = (rawResponse: RawHttpResponse) => Promise<any>;
 
 export interface BodyParserOptions {
   bodyCasing?: BodyCasing;
+  customCaseConverter?: CaseConverter;
   defaultParser?: BodyParserImplementation;
 }
 
 export const bodyParser = ({
   bodyCasing,
+  customCaseConverter,
   defaultParser = raw => raw.arrayBuffer(),
 }: BodyParserOptions = {}): BodyParser<any> => {
-  const caseConverter = getCaseConverter(bodyCasing);
+  const caseConverter = customCaseConverter ?? getCaseConverter(bodyCasing);
 
   const getContentType = (rawResponse: RawHttpResponse) => (rawResponse.headers.get('content-type') || '')
     .split(';')

--- a/packages/http/src/helpers/caseConversion.helper.ts
+++ b/packages/http/src/helpers/caseConversion.helper.ts
@@ -35,6 +35,8 @@ export const deepKeyMap = (object: any, mapper: (key: string) => string): any =>
   return object;
 };
 
+export type CaseConverter = (object: any) => any;
+
 export const toCamelCase = (object: any) => deepKeyMap(object, key => splitWords(key)
   .map((word, index) => index > 0
     ? word[0].toUpperCase() + word.slice(1).toLowerCase()

--- a/packages/http/src/httpResponse.ts
+++ b/packages/http/src/httpResponse.ts
@@ -1,5 +1,5 @@
 import { HttpHeaders, HttpResponse, RawHttpResponse } from './httpClient.types';
-import { bodyParser } from './bodyParser';
+import { bodyParser, BodyParserOptions } from './bodyParser';
 import { encodeArrayBuffer, encodeText } from './helpers/encoder.helper';
 import { HttpStatusText } from './httpCodes';
 import { HttpResponseHeaders } from './httpResponseHeaders';
@@ -10,6 +10,7 @@ interface HttpResponseOptions {
   headers?: HttpHeaders;
   status: number;
   body?: TypedArray | string;
+  bodyParserOptions?: BodyParserOptions;
 }
 
 export const createHttpResponse = ({
@@ -17,6 +18,7 @@ export const createHttpResponse = ({
   headers,
   body,
   status,
+  bodyParserOptions = {},
 }: HttpResponseOptions): HttpResponse => {
   const arrayBuffer = encodeArrayBuffer(body);
   const rawResponse: RawHttpResponse = {
@@ -32,5 +34,5 @@ export const createHttpResponse = ({
     headers: new HttpResponseHeaders(headers),
     ok: status < 400,
   };
-  return bodyParser()(rawResponse);
+  return bodyParser(bodyParserOptions)(rawResponse);
 };


### PR DESCRIPTION
Not every API conforms to good practices, or even common sense. For instance someone could use dynamic date strings as keys in an object, which for dates with time zones including `-` may cause a lot of problems. Hence, handling such incoming data may require using a custom body parser with some non-standard case conversion function. 

However, in the current implementation it is not easy and requires duplicating some code. This could be alleviated by exposing some logic hidden within `bodyParser` as is proposed in this PR. Then creating such a body parser would be simplified to:

```typescript
export const bodyParserWithCustomCaseConverter = (): BodyParser<any> => {
  const customCaseConverter: (object: any) => any = (object) => { /* custom case conversion goes here */ };
  const getContentType = createGetContentType();

  return (rawResponse: RawHttpResponse): HttpResponse => {
    const contentType = getContentType(rawResponse)[0];
    const parsedBody = switchContentType(contentType, createContentTypeToBodyParserMap(getContentType, customCaseConverter), raw => raw.arrayBuffer());

    return {
      ...rawResponse,
      parsedBody: () => parsedBody(rawResponse),
    };
  };
};
```